### PR TITLE
Compatibility with 1.19.3

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 12,
     "description": "§1GeruDoku\n§2v1.19.x by Syben"
   }
 }


### PR DESCRIPTION
Current version of GeruDoku gives message about an incompatible pack meant for an older version of Minecraft.

This page indicates that the `pack_format` should be 12 for 1.19.3

https://minecraft.fandom.com/wiki/Pack_format